### PR TITLE
Refactor client initialization and remove dotenv

### DIFF
--- a/src/fmp_mcp_server/client.py
+++ b/src/fmp_mcp_server/client.py
@@ -4,9 +4,6 @@ import os
 from typing import Any
 
 import httpx
-from dotenv import load_dotenv
-
-load_dotenv()
 
 
 class FMPClient:


### PR DESCRIPTION
This commit fixes an issue where the Docker container would fail to start.

The changes include:
1.  Removing the `load_dotenv()` call from the FMP client. In a containerized environment, environment variables should be injected by the runtime (e.g., using `docker run --env-file`), not loaded by the application itself.
2.  Refactoring the FMPServer to use a getter method (`get_fmp_client`) for lazy initialization of the FMPClient. This makes the startup process more robust by ensuring the client is only created when a tool is called, preventing potential startup crashes related to API key configuration.