### PR TITLE
Refactor the FMP client to use the new stable API endpoints.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Financial Modelling Prep API Configuration
 FMP_API_KEY=your_api_key_here
-FMP_BASE_URL=https://financialmodelingprep.com/api/v3
+FMP_BASE_URL=https://financialmodelingprep.com/stable
 
 # Optional: Rate limiting configuration
 RATE_LIMIT_REQUESTS_PER_MINUTE=300

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     restart: unless-stopped
     environment:
       - FMP_API_KEY=${FMP_API_KEY}
-      - FMP_BASE_URL=${FMP_BASE_URL:-https://financialmodelingprep.com/api/v3}
+      - FMP_BASE_URL=${FMP_BASE_URL:-https://financialmodelingprep.com/stable}
       - RATE_LIMIT_REQUESTS_PER_MINUTE=${RATE_LIMIT_REQUESTS_PER_MINUTE:-300}
     env_file:
       - .env

--- a/src/fmp_mcp_server/client.py
+++ b/src/fmp_mcp_server/client.py
@@ -19,7 +19,7 @@ class FMPClient:
         self.api_key = api_key or os.getenv("FMP_API_KEY")
         self.base_url = base_url or os.getenv(
             "FMP_BASE_URL",
-            "https://financialmodelingprep.com/api/v3",
+            "https://financialmodelingprep.com/stable",
         )
 
         if not self.api_key:
@@ -53,12 +53,12 @@ class FMPClient:
 
     async def get_company_profile(self, symbol: str) -> list[dict[str, Any]]:
         """Get company profile information."""
-        result = await self._request(f"profile/{symbol}")
+        result = await self._request("profile", {"symbol": symbol})
         return result if isinstance(result, list) else [result]
 
     async def get_quote(self, symbol: str) -> list[dict[str, Any]]:
         """Get real-time stock quote."""
-        result = await self._request(f"quote/{symbol}")
+        result = await self._request("quote", {"symbol": symbol})
         return result if isinstance(result, list) else [result]
 
     async def get_income_statement(
@@ -69,8 +69,8 @@ class FMPClient:
     ) -> list[dict[str, Any]]:
         """Get income statement data."""
         result = await self._request(
-            f"income-statement/{symbol}",
-            {"period": period, "limit": limit},
+            "income-statement",
+            {"symbol": symbol, "period": period, "limit": limit},
         )
         return result if isinstance(result, list) else [result]
 
@@ -82,8 +82,8 @@ class FMPClient:
     ) -> list[dict[str, Any]]:
         """Get balance sheet data."""
         result = await self._request(
-            f"balance-sheet-statement/{symbol}",
-            {"period": period, "limit": limit},
+            "balance-sheet-statement",
+            {"symbol": symbol, "period": period, "limit": limit},
         )
         return result if isinstance(result, list) else [result]
 
@@ -95,8 +95,8 @@ class FMPClient:
     ) -> list[dict[str, Any]]:
         """Get cash flow statement data."""
         result = await self._request(
-            f"cash-flow-statement/{symbol}",
-            {"period": period, "limit": limit},
+            "cash-flow-statement",
+            {"symbol": symbol, "period": period, "limit": limit},
         )
         return result if isinstance(result, list) else [result]
 
@@ -108,8 +108,8 @@ class FMPClient:
     ) -> list[dict[str, Any]]:
         """Get key financial metrics."""
         result = await self._request(
-            f"key-metrics/{symbol}",
-            {"period": period, "limit": limit},
+            "key-metrics",
+            {"symbol": symbol, "period": period, "limit": limit},
         )
         return result if isinstance(result, list) else [result]
 
@@ -121,24 +121,24 @@ class FMPClient:
     ) -> list[dict[str, Any]]:
         """Get financial ratios."""
         result = await self._request(
-            f"ratios/{symbol}",
-            {"period": period, "limit": limit},
+            "ratios",
+            {"symbol": symbol, "period": period, "limit": limit},
         )
         return result if isinstance(result, list) else [result]
 
     async def get_dcf_valuation(self, symbol: str) -> list[dict[str, Any]]:
         """Get DCF valuation."""
-        result = await self._request(f"discounted-cash-flow/{symbol}")
+        result = await self._request("discounted-cash-flow", {"symbol": symbol})
         return result if isinstance(result, list) else [result]
 
     async def get_financial_score(self, symbol: str) -> list[dict[str, Any]]:
         """Get financial score."""
-        result = await self._request(f"score/{symbol}")
+        result = await self._request("financial-scores", {"symbol": symbol})
         return result if isinstance(result, list) else [result]
 
     async def get_market_cap(self, symbol: str) -> list[dict[str, Any]]:
         """Get market capitalization."""
-        result = await self._request(f"market-capitalization/{symbol}")
+        result = await self._request("market-capitalization", {"symbol": symbol})
         return result if isinstance(result, list) else [result]
 
     async def search_companies(
@@ -147,7 +147,9 @@ class FMPClient:
         limit: int = 10,
     ) -> list[dict[str, Any]]:
         """Search for companies."""
-        result = await self._request("search", {"query": query, "limit": limit})
+        result = await self._request(
+            "search-symbol", {"query": query, "limit": limit}
+        )
         return result if isinstance(result, list) else [result]
 
     async def get_sector_performance(self) -> list[dict[str, Any]]:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,7 +20,7 @@ class TestFMPClient:
         """Test initialization with API key."""
         client = FMPClient(api_key="test_key")
         assert client.api_key == "test_key"
-        assert client.base_url == "https://financialmodelingprep.com/api/v3"
+        assert client.base_url == "https://financialmodelingprep.com/stable"
 
     @pytest.mark.asyncio
     async def test_request_adds_api_key(self):
@@ -36,7 +36,7 @@ class TestFMPClient:
             result = await client._request("test-endpoint")
 
             mock_get.assert_called_once_with(
-                "https://financialmodelingprep.com/api/v3/test-endpoint",
+                "https://financialmodelingprep.com/stable/test-endpoint",
                 params={"apikey": "test_key"},
             )
             assert result == {"test": "data"}
@@ -51,5 +51,18 @@ class TestFMPClient:
 
             result = await client.get_company_profile("AAPL")
 
-            mock_request.assert_called_once_with("profile/AAPL")
+            mock_request.assert_called_once_with("profile", {"symbol": "AAPL"})
+            assert result == [{"symbol": "AAPL"}]
+
+    @pytest.mark.asyncio
+    async def test_get_quote(self):
+        """Test get quote."""
+        client = FMPClient(api_key="test_key")
+
+        with patch.object(client, "_request") as mock_request:
+            mock_request.return_value = {"symbol": "AAPL"}
+
+            result = await client.get_quote("AAPL")
+
+            mock_request.assert_called_once_with("quote", {"symbol": "AAPL"})
             assert result == [{"symbol": "AAPL"}]


### PR DESCRIPTION
This change updates the base URL from `https://financialmodelingprep.com/api/v3` to `https://financialmodelingprep.com/stable`.

It also refactors all the methods in the `FMPClient` to pass the stock symbol and other parameters as query parameters instead of embedding them in the URL path. This aligns with the new API structure.

The configuration files (`docker-compose.yml`, `.env.example`) and the tests have been updated to reflect these changes.